### PR TITLE
Improvements for Home Assistant discovery

### DIFF
--- a/classes/protocol_settings.py
+++ b/classes/protocol_settings.py
@@ -189,6 +189,7 @@ class registry_map_entry:
     register_byte : int
     ''' byte offset for canbus ect... '''
     variable_name : str
+    display_name : str
     documented_name : str
     unit : str
     unit_mod : float
@@ -500,14 +501,14 @@ class protocol_settings:
             #endregion unit
 
 
-            variable_name = row["variable name"] if row["variable name"] else row["documented name"]
-            variable_name = variable_name.strip().lower().replace(" ", "_").replace("__", "_") #clean name
+            display_name = row["variable name"] if row["variable name"] else row["documented name"]
+            variable_name = display_name.strip().lower().replace(" ", "_").replace("__", "_") #clean name
 
             if re.search(r"[^a-zA-Z0-9\_]", variable_name) :
                 self._log.warning("Invalid Name : " + str(variable_name) + " reg: " + str(row["register"]) + " doc name: " + str(row["documented name"]) + " path: " + str(path))
 
-
-            if not variable_name and not row["documented name"]: #skip empty entry / no name. todo add more invalidator checks.
+            if not variable_name: #skip empty entry / no name. todo add more invalidator checks.
+                self._log.warning(f"Skipping empty name for register: {row['register']}")
                 return
 
             #region data type
@@ -653,6 +654,7 @@ class protocol_settings:
                                             register_bit=register_bit,
                                             register_byte= register_byte,
                                             variable_name= variable_name,
+                                            display_name = display_name,
                                             documented_name = row["documented name"],
                                             unit= str(unit_symbol),
                                             unit_mod= unit_multiplier,

--- a/classes/transports/mqtt.py
+++ b/classes/transports/mqtt.py
@@ -232,8 +232,9 @@ class mqtt(transport_base):
                 continue
 
 
-            clean_name = item.variable_name.lower().replace(" ", "_").strip()
-            if not clean_name: #if name is empty, skip
+            clean_name = item.variable_name
+            if not clean_name: #if name is empty, skip^
+                self._log.warning(f"Skipping empty name for item: {item.register}")
                 continue
 
             if False:
@@ -262,8 +263,7 @@ class mqtt(transport_base):
             if item.unit:
                 disc_payload["unit_of_measurement"] = item.unit
 
-
-            discovery_topic = self.discovery_topic+"/sensor/HN-" + from_transport.device_serial_number  + writePrefix + "/" + disc_payload["name"].replace(" ", "_") + "/config"
+            discovery_topic = self.discovery_topic+"/sensor/HN-" + from_transport.device_serial_number  + writePrefix + "/" + clean_name + "/config"
 
             self.client.publish(discovery_topic,
                                        json.dumps(disc_payload),qos=1, retain=True)

--- a/classes/transports/mqtt.py
+++ b/classes/transports/mqtt.py
@@ -214,7 +214,7 @@ class mqtt(transport_base):
         device["manufacturer"] = from_transport.device_manufacturer
         device["model"] = from_transport.device_model
         device["identifiers"] = "hotnoob_" + from_transport.device_model + "_" + from_transport.device_serial_number
-        device["name"] = from_transport.device_name
+        device["name"] = from_transport.device_name.replace("_", " ").strip()
 
         registry_map : list[registry_map_entry] = []
         for entries in from_transport.protocolSettings.registry_map.values():

--- a/classes/transports/mqtt.py
+++ b/classes/transports/mqtt.py
@@ -247,7 +247,7 @@ class mqtt(transport_base):
             disc_payload = {}
             disc_payload["availability_topic"] = self.base_topic + "/" + from_transport.device_identifier + "/availability"
             disc_payload["device"] = device
-            disc_payload["name"] = clean_name
+            disc_payload["name"] = item.display_name
             disc_payload["unique_id"] = "hotnoob_" + from_transport.device_serial_number + "_"+clean_name
 
             writePrefix = ""

--- a/classes/transports/transport_base.py
+++ b/classes/transports/transport_base.py
@@ -94,6 +94,7 @@ class transport_base:
 
         if settings:
             self.device_serial_number = settings.get(["device_serial_number", "serial_number"], self.device_serial_number)
+            self.device_model = settings.get(["device_model", "model"], self.device_model)
             self.device_manufacturer = settings.get(["device_manufacturer", "manufacturer"], self.device_manufacturer)
             self.device_name = settings.get(["device_name", "name"], fallback=self.device_manufacturer+"_"+self.device_serial_number)
             self.bridge = settings.get("bridge", self.bridge)

--- a/classes/transports/transport_base.py
+++ b/classes/transports/transport_base.py
@@ -125,6 +125,8 @@ class transport_base:
 
     def update_identifier(self):
         self.device_identifier = self.device_serial_number.strip().lower()
+        if self.device_name[-1] == "_": # Device name is missing serial number
+            self.device_name = self.device_name + self.device_serial_number
 
     def init_bridge(self, from_transport : "transport_base"):
         pass


### PR DESCRIPTION
## Display Name
Added display_name to allow displaying original variable name / documented name in Home Assistant
![image](https://github.com/user-attachments/assets/f37d400e-3412-4594-b138-af8b74d3b06c)
Before: Devices were displayed e.g. as `ac_discharge_watts`
### Related Commits
- f4f6cf792ba8eee39fce6d1c50e35dd1faf2b52e
## Device Serial
If serial number is auto discovered and not provided in configuration, it was not updated in the device dict and therefore not available in Home Assistant.
Also, the device name in Home Assistant was shown with "_" separation, would also allow space for nicer displaying.
Now:
![image](https://github.com/user-attachments/assets/0e67ae94-f651-47b8-be94-b98ef9b30752)
Before: `Growatt_`
### Related Commits
- e8000c090fd92e0e6539fc65d5fe895cd9b4b1e2
- 64bb8978c857f34d4801214463db9a5dce0d1159
## Model Number
Device model number has not been parsed from configuration and was not displayed in Home Assistant.
Now (if `model` available in `config.cfg`, here `model = SPF6000 ES Plus`): 
![image](https://github.com/user-attachments/assets/ce798541-c6d7-4fa6-aee6-e831c67f1ad6)
### Related Commits
- 88fe48efd6e86a7c89e164cfd285d0b7afc5606c
## Redundant Name Cleaning
Name cleaning is already done in https://github.com/HotNoob/PythonProtocolGateway/blob/86b7e6451da5e5522e4b2fd08ff018efbe807533/classes/protocol_settings.py#L504 and has been removed from `mqtt.py` in 7ce4c43c6205484d6779a37f09c2a8441cc06de6.
## Add Attribute for `availability_topic`
Availability topic in offline message was not matching topic in online message:
Offline:
https://github.com/HotNoob/PythonProtocolGateway/blob/86b7e6451da5e5522e4b2fd08ff018efbe807533/classes/transports/mqtt.py#L111
Online:
https://github.com/HotNoob/PythonProtocolGateway/blob/86b7e6451da5e5522e4b2fd08ff018efbe807533/classes/transports/mqtt.py#L164
Added one common availability topic in 1683c96f28e920f0220650043b8caa361b40e0ff.

Thanks in advance for considering my changes.