### PR TITLE
Make sure device_model is read from the config

### DIFF
--- a/classes/transports/transport_base.py
+++ b/classes/transports/transport_base.py
@@ -95,6 +95,7 @@ class transport_base:
         if settings:
             self.device_serial_number = settings.get(["device_serial_number", "serial_number"], self.device_serial_number)
             self.device_manufacturer = settings.get(["device_manufacturer", "manufacturer"], self.device_manufacturer)
+            self.device_model = settings.get(["device_model", "model"], self.device_model)
             self.device_name = settings.get(["device_name", "name"], fallback=self.device_manufacturer+"_"+self.device_serial_number)
             self.bridge = settings.get("bridge", self.bridge)
             self.read_interval = settings.getfloat("read_interval", self.read_interval)


### PR DESCRIPTION
The value of `device_model` is used in the mqtt implementation but it's actually never read from the config. This is a fix. 